### PR TITLE
Fix flashing procedure, small modifications to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ make menuconfig KCONFIG_CONFIG=config.nis
        - [_] Support LCD devices
        - [ * ] Support external sensor devices
        - [_] Support lis2dw 3-axis accelerometer
+       - [_] Support ldc1612 eddy current sensor
        - [_] Support software based I2C "bit-banging"
        - [ * ] Support software based SPI "bit-banging"
     
@@ -61,16 +62,15 @@ lsusb
    
 5. Run the following command to Flash your NIS, replace the xxxx:yyyy with the ID from the previous step.
 ```bash
-make flash FLASH_DEVICE=xxxx:yyyy
+make flash KCONFIG_CONFIG=config.nis FLASH_DEVICE=xxxx:yyyy
 ```
 Example
 ```bash
-make flash FLASH_DEVICE=0483:df11
+make flash KCONFIG_CONFIG=config.nis FLASH_DEVICE=0483:df11
 ```
    - You may see what appears to be an "error" after flashing your board.
    - As long as you see the File downloded successfully text you are good to proceed.
-6. After it has finished flashing, run the following command again. As long as the device is not showing it is in DFU Mode like in step 3, you are good to move onto the next step.
-7. Run the following command to find the devices serial port name
+6. The command "make flash" should automatically reset the microcontroller. Run the following command to find the devices serial port name
 ```bash
 ls /dev/serial/by-id/*
 ```


### PR DESCRIPTION
Upon receiving my new NIS, I needed to update the Klipper firmware as the pre-installed version was not compatible with the Klipper version on my host.

I followed the original instructions provided; however, they failed to include the specification of the configuration file "KCONFIG_CONFIG=config.nis" in the flashing command.

As a result, the make flash command defaulted to using the standard configuration file instead of "config.nis", leading to a failed upload due to a mismatch in the firmware configuration settings.

I have corrected the relevant sections in the README and added a line to explain the configuration for the new optional feature "Support for the ldc1612 eddy current sensor".

I would appreciate if this pull request could be merged to assist others in getting their NIS up and running.
Alternatively, you are free to copy/paste my changes if you prefer to limit PRs to FYSETC employees.